### PR TITLE
Feature/upgrade vue i18n to stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,8 @@ $t('Hello, how are you?')
 
 Better right?, we can directly see the original text, and it's much simpler to translate, we also won't need to define keys because **the original text is the key!**.
 
+> **NOTE:** After migrate vueI18n version from `9.2.0-beta.30` to `9.2.2` (stable), the i18n of the App do not work with legacy parameter set true of without it, only works if it is set false, so, you could ask 'This will make that my project fails with legacy translations?' the answer is NO!. Though legacy parameter is set false, you can use $t() translation mode, but you can not use $tc() translation mode. So, if you have some $tc() translation, we recomment use the useI18n composable on script setup and use t() translation mode.
+
 **Browser language detection**
 
 The default language would match the language of the browser,

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,45 +127,45 @@
       }
     },
     "@intlify/core-base": {
-      "version": "9.2.0-beta.22",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.2.0-beta.22.tgz",
-      "integrity": "sha512-SqgQx+npGJ8XgY920FoHnvfo7Th4bEFPxOUrMquqHCHH7J/HSLV6Xppzf8wE1ZzCWjn1wmUHkavTW9ASNCXj0Q==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.2.2.tgz",
+      "integrity": "sha512-JjUpQtNfn+joMbrXvpR4hTF8iJQ2sEFzzK3KIESOx+f+uwIjgw20igOyaIdhfsVVBCds8ZM64MoeNSx+PHQMkA==",
       "requires": {
-        "@intlify/devtools-if": "9.2.0-beta.22",
-        "@intlify/message-compiler": "9.2.0-beta.22",
-        "@intlify/shared": "9.2.0-beta.22",
-        "@intlify/vue-devtools": "9.2.0-beta.22"
+        "@intlify/devtools-if": "9.2.2",
+        "@intlify/message-compiler": "9.2.2",
+        "@intlify/shared": "9.2.2",
+        "@intlify/vue-devtools": "9.2.2"
       }
     },
     "@intlify/devtools-if": {
-      "version": "9.2.0-beta.22",
-      "resolved": "https://registry.npmjs.org/@intlify/devtools-if/-/devtools-if-9.2.0-beta.22.tgz",
-      "integrity": "sha512-TRpig6P7hMZejDvmwTGygf+TbGUkeICnIMtNqKCMkAw78Yoc5FhgaKTCkK72Gjcmul7V9CdOF+ro/xtzY6MQGQ==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-if/-/devtools-if-9.2.2.tgz",
+      "integrity": "sha512-4ttr/FNO29w+kBbU7HZ/U0Lzuh2cRDhP8UlWOtV9ERcjHzuyXVZmjyleESK6eVP60tGC9QtQW9yZE+JeRhDHkg==",
       "requires": {
-        "@intlify/shared": "9.2.0-beta.22"
+        "@intlify/shared": "9.2.2"
       }
     },
     "@intlify/message-compiler": {
-      "version": "9.2.0-beta.22",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.2.0-beta.22.tgz",
-      "integrity": "sha512-+Nx8IpKcXBQ7L+f6UWLQf/iReD7rotBkV4oxUX1rKMQgaJToYB1ovrPYNoNDd6aK4rEQ9sJoM5nd2+ENmCs7dA==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.2.2.tgz",
+      "integrity": "sha512-IUrQW7byAKN2fMBe8z6sK6riG1pue95e5jfokn8hA5Q3Bqy4MBJ5lJAofUsawQJYHeoPJ7svMDyBaVJ4d0GTtA==",
       "requires": {
-        "@intlify/shared": "9.2.0-beta.22",
+        "@intlify/shared": "9.2.2",
         "source-map": "0.6.1"
       }
     },
     "@intlify/shared": {
-      "version": "9.2.0-beta.22",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.2.0-beta.22.tgz",
-      "integrity": "sha512-IyU9Trx1d5EZgAh6/3y0+efgko5xRw1iTwpM19qublZsTSnDSkHB8NnSyHVZrMARj+LgZgL7pKktsSO5os9k2A=="
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.2.2.tgz",
+      "integrity": "sha512-wRwTpsslgZS5HNyM7uDQYZtxnbI12aGiBZURX3BTR9RFIKKRWpllTsgzHWvj3HKm3Y2Sh5LPC1r0PDCKEhVn9Q=="
     },
     "@intlify/vue-devtools": {
-      "version": "9.2.0-beta.22",
-      "resolved": "https://registry.npmjs.org/@intlify/vue-devtools/-/vue-devtools-9.2.0-beta.22.tgz",
-      "integrity": "sha512-CZwrIFGiXl9q6Rrqyqtb3P+wwG7f0FcMvbQqJf2CnCsT7rLi4O+qbSzY5ZjN5J0bsLTfL2a4UIhxIlim4Ea+hQ==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@intlify/vue-devtools/-/vue-devtools-9.2.2.tgz",
+      "integrity": "sha512-+dUyqyCHWHb/UcvY1MlIpO87munedm3Gn6E9WWYdWrMuYLcoIoOEVDWSS8xSwtlPU+kA+MEQTP6Q1iI/ocusJg==",
       "requires": {
-        "@intlify/core-base": "9.2.0-beta.22",
-        "@intlify/shared": "9.2.0-beta.22"
+        "@intlify/core-base": "9.2.2",
+        "@intlify/shared": "9.2.2"
       }
     },
     "@nestjs/common": {
@@ -3592,14 +3592,21 @@
       }
     },
     "vue-i18n": {
-      "version": "9.2.0-beta.22",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.2.0-beta.22.tgz",
-      "integrity": "sha512-XnkGLhC1ESZYiCpWnTkAsc3/z8p2ntu5dmQjp9M0hhOZi5w8JZ8VQieJiiq5MFlqjVeIxNkGMn6HM0hvC4xtFA==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.2.2.tgz",
+      "integrity": "sha512-yswpwtj89rTBhegUAv9Mu37LNznyu3NpyLQmozF3i1hYOhwpG8RjcjIFIIfnu+2MDZJGSZPXaKWvnQA71Yv9TQ==",
       "requires": {
-        "@intlify/core-base": "9.2.0-beta.22",
-        "@intlify/shared": "9.2.0-beta.22",
-        "@intlify/vue-devtools": "9.2.0-beta.22",
-        "@vue/devtools-api": "^6.0.0-beta.13"
+        "@intlify/core-base": "9.2.2",
+        "@intlify/shared": "9.2.2",
+        "@intlify/vue-devtools": "9.2.2",
+        "@vue/devtools-api": "^6.2.1"
+      },
+      "dependencies": {
+        "@vue/devtools-api": {
+          "version": "6.4.4",
+          "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.4.4.tgz",
+          "integrity": "sha512-Ku31WzpOV/8cruFaXaEZKF81WkNnvCSlBY4eOGtz5WMSdJvX1v1WWlSMGZeqUwPtQ27ZZz7B62erEMq8JDjcXw=="
+        }
       }
     },
     "vue-i18n-extract": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "axios": "^0.24.0",
     "bootstrap": "^5.1.3",
     "vue": "^3.2.16",
-    "vue-i18n": "^9.2.0-beta.22",
+    "vue-i18n": "^9.2.2",
     "vue-router": "^4.0.12"
   },
   "devDependencies": {

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -11,7 +11,15 @@ watchEffect(() => {
 </script>
 
 <template>
-  <img alt="Vue logo" src="@/assets/logo.png" style="height: 200px" />
+  <img
+    alt="Vue logo"
+    src="@/assets/logo.png"
+    style="
+       {
+        height: 200px;
+      }
+    "
+  />
 
   <h1>{{ title }}</h1>
   <p>{{ msg }}</p>
@@ -25,11 +33,7 @@ watchEffect(() => {
   <p>
     <button class="btn btn-primary" @click="count++">
       <i-mdi-thumb-up />
-      {{
-        $tc('This template has no likes | This template has one like | This template has {likes} likes', count, {
-          likes: count,
-        })
-      }}
+      {{ $t('This template has no likes | This template has one like | This template has {likes} likes', count) }}
     </button>
   </p>
 </template>

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -34,7 +34,7 @@ const messages = getMessages()
 const i18n = createI18n({
   locale: Object.keys(messages).includes(BROWSER_LANGUAGE) ? BROWSER_LANGUAGE : DEFAULT_LANGUAGE,
   fallbackLocale: DEFAULT_LANGUAGE,
-  legacy: true, // Enables $t(), $tc(), etc in templates
+  legacy: false, // Even though legacy mode is disabled, you can still use $t() in templates, but $tc() is not permitted. Be careful, if you set this on true or erase this parameter, the application could fail
   messages,
 })
 


### PR DESCRIPTION
This change migrate vueI18n version from 9.2.0-beta.30 to 9.2.2 (stable), the i18n of the App do not work with legacy parameter set true of without it, only works if it is set false. Though legacy parameter is set false, we can use $t() translation mode, but we can not use $tc() translation mode. So, if we have some $tc() translation mode, we should use the useI18n composable on script setup and use t() translation mode.